### PR TITLE
Feature: add infomation of original/jp project

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -321,8 +321,9 @@ strong {
 }
 
 .header p {
-  margin: 0;
+  margin: 10px 0;
   line-height: 1;
+  font-size: 15px;
 }
 
 .nav {

--- a/config.toml
+++ b/config.toml
@@ -1,5 +1,5 @@
 baseURL = "/"
-title = "Istio By Example"
+title = "Istio By Example (ja)"
 theme = "hugo-notepadium"
 copyright = ""
 relativeURLs = true # use relative path at images in markdown

--- a/layouts/partials/footer.html
+++ b/layouts/partials/footer.html
@@ -1,4 +1,5 @@
 <section id="footer" class="footer">
     <p>Made with ❤️ by <a href="https://twitter.com/askmeegs">Megan O'Keefe</a> | <a href="https://github.com/askmeegs/istiobyexample">Source</a> | <a href="https://github.com/cntrump/hugo-notepadium">Theme</a></p>
+    <p>Localized by <a href="https://github.com/istiobyexample-ja/istiobyexample">Istio by Example-ja Project</a></p>
 </section>
 {{- template "_internal/google_analytics_async.html" . -}}

--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -2,10 +2,10 @@
     <p><a class="home" href="{{- `/` -}}">
             {{- with .Site.Params.logo -}}
             <img class="site-logo" src="{{- . -}}" alt />
-            <span class="site-name">Istio By Example</span>
+            <span class="site-name">Istio By Example (ja)</span>
             {{- else -}}
             <span class="site-name">{{- .Site.Title -}}</span>
             {{- end -}}
-
         </a></p>
+    <p>This site is translated from <a href="https://istiobyexample.dev">Istio By Example</a></p>
 </section>

--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -2,10 +2,10 @@
     <p><a class="home" href="{{- `/` -}}">
             {{- with .Site.Params.logo -}}
             <img class="site-logo" src="{{- . -}}" alt />
-            <span class="site-name">Istio By Example (ja)</span>
+            <span class="site-name">Istio By Example</span>
             {{- else -}}
             <span class="site-name">{{- .Site.Title -}}</span>
             {{- end -}}
         </a></p>
-    <p>This site is translated from <a href="https://istiobyexample.dev">Istio By Example</a></p>
+    <p>This is a translation of <a href="https://istiobyexample.dev">Istio By Example</a> | こちらは<a href="https://istiobyexample.dev">Istio By Example</a>を翻訳したものです</p>
 </section>

--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -7,5 +7,5 @@
             <span class="site-name">{{- .Site.Title -}}</span>
             {{- end -}}
         </a></p>
-    <p>This is a translation of <a href="https://istiobyexample.dev">Istio By Example</a> | こちらは<a href="https://istiobyexample.dev">Istio By Example</a>を翻訳したものです</p>
+    <p>本サイトは <a href="https://istiobyexample.dev">Istio By Example</a> を和訳したものです</p>
 </section>


### PR DESCRIPTION
PR for issue #9 

本家とjaを見分けられるよう以下を追加しました。

- Headerのタイトルに`(ja)`を追加
- Headerにオリジナルサイトへのリンクを追加
- Footerに本プロジェクトのリンクを追加

見た目は以下のようになります。
英語に自信がないため，上手い言い方などあればコメント下さい...。

header
![Screenshot_2020-04-09 Istio By Example](https://user-images.githubusercontent.com/34432106/78883086-f8224c80-7a93-11ea-8502-47a0968be148.png)

footer
![Screenshot_2020-04-09 Istio By Example(2)](https://user-images.githubusercontent.com/34432106/78883101-fd7f9700-7a93-11ea-8178-7db90beec513.png)
