### PR TITLE
Bugfix: remove duplicated css link path

### DIFF
--- a/layouts/partials/style.html
+++ b/layouts/partials/style.html
@@ -63,4 +63,4 @@
 {{- end -}}
 
 {{- $coreCSS = slice $coreCSS $syntaxCSS | resources.Concat "css/core.css" | minify | fingerprint "sha384" -}}
-<link rel="stylesheet" href="{{- $coreCSS.RelPermalink | relURL -}}" integrity="{{- $coreCSS.Data.Integrity -}}">
+<link rel="stylesheet" href="{{- $coreCSS.RelPermalink -}}" integrity="{{- $coreCSS.Data.Integrity -}}">

--- a/layouts/partials/style.html
+++ b/layouts/partials/style.html
@@ -63,4 +63,4 @@
 {{- end -}}
 
 {{- $coreCSS = slice $coreCSS $syntaxCSS | resources.Concat "css/core.css" | minify | fingerprint "sha384" -}}
-<link rel="stylesheet" href="{{- $coreCSS.RelPermalink -}}" integrity="{{- $coreCSS.Data.Integrity -}}">
+<link rel="stylesheet" href="{{- $coreCSS.RelPermalink | absURL -}}" integrity="{{- $coreCSS.Data.Integrity -}}">


### PR DESCRIPTION
baseURLにpathが含まれる場合，cssでrelURLを使うとbaseURLのpathが二重になるため，absURLを使うようにしました。

before
```
./istiobyexample/istiobyexample/css/core.min~
```

after
```
https://istiobyexample-ja.github.io/istiobyexample/css/core.min~
```