### PR TITLE
shorten header note for mobile layouts

### DIFF
--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -7,5 +7,5 @@
             <span class="site-name">{{- .Site.Title -}}</span>
             {{- end -}}
         </a></p>
-    <p>本サイトは <a href="https://istiobyexample.dev">Istio By Example</a> を和訳したものです</p>
+    <p>本サイトは <a href="https://istiobyexample.dev">Istio By Example</a> の和訳です</p>
 </section>


### PR DESCRIPTION
スマフォだとタイトル下注釈が最後数文字だけ折り返されるため，文を短くしました。

before
本サイトは Istio By Example を和訳したものです

after
本サイトは Istio By Example の和訳です